### PR TITLE
Admin withdraw exit

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -1211,7 +1211,7 @@ contract Exchange_v4 is EIP712, IExchange, Owned {
    *
    * @param wallet Address of exited wallet
    */
-  function withdrawExitAdmin(address wallet) public onlyAdmin onlyWhenExitFundHasOpenPositions {
+  function withdrawExitAdmin(address wallet) public onlyAdminOrDispatcher onlyWhenExitFundHasOpenPositions {
     (uint256 exitFundPositionOpenedAtBlockNumber_, uint64 quantity) = Withdrawing.withdrawExitAdmin_delegatecall(
       Withdrawing.WithdrawExitArguments(wallet, custodian, exitFundWallet, oraclePriceAdapter, quoteTokenAddress),
       exitFundPositionOpenedAtBlockNumber,

--- a/contracts/libraries/Withdrawing.sol
+++ b/contracts/libraries/Withdrawing.sol
@@ -140,7 +140,7 @@ library Withdrawing {
     mapping(string => mapping(address => MarketOverrides)) storage marketOverridesByBaseAssetSymbolAndWallet,
     mapping(string => Market) storage marketsByBaseAssetSymbol,
     mapping(address => WalletExit) storage walletExits
-  ) public returns (uint256, uint64) {
+  ) public returns (uint256 exitFundPositionOpenedAtBlockNumber_, uint64 quantity) {
     Funding.applyOutstandingWalletFunding(
       arguments.wallet,
       balanceTracking,
@@ -190,7 +190,7 @@ library Withdrawing {
         balanceTracking,
         baseAssetSymbolsWithOpenPositionsByWallet
       ),
-      // Quote quantity will never be negative per design of exit quote calculations
+      // Quote quantity validated to be non-negative by `validateExitQuoteQuantityAndCoerceIfNeeded`
       uint64(walletQuoteQuantityToWithdraw)
     );
   }
@@ -206,7 +206,7 @@ library Withdrawing {
     mapping(string => mapping(address => MarketOverrides)) storage marketOverridesByBaseAssetSymbolAndWallet,
     mapping(string => Market) storage marketsByBaseAssetSymbol,
     mapping(address => WalletExit) storage walletExits
-  ) public returns (uint256, uint64) {
+  ) public returns (uint256 exitFundPositionOpenedAtBlockNumber_, uint64 quantity) {
     require(walletExits[arguments.wallet].exists, "Wallet not exited");
 
     Funding.applyOutstandingWalletFunding(
@@ -243,7 +243,7 @@ library Withdrawing {
         balanceTracking,
         baseAssetSymbolsWithOpenPositionsByWallet
       ),
-      // Quote quantity will never be negative per design of exit quote calculations
+      // Quote quantity validated to be non-negative by `validateExitQuoteQuantityAndCoerceIfNeeded`
       uint64(walletQuoteQuantityToWithdraw)
     );
   }

--- a/test/exits.ts
+++ b/test/exits.ts
@@ -338,7 +338,7 @@ describe('Exchange', function () {
       ).to.eventually.be.rejectedWith(/wallet not exited/i);
     });
 
-    it('should revert when not called by admin', async function () {
+    it('should revert when not called by admin or dispatch', async function () {
       await exchange.connect(trader1Wallet).exitWallet();
       exchange.withdrawExit(trader1Wallet.address);
 


### PR DESCRIPTION
Adds the ability for the admin or dispatcher wallets to execute an exit withdrawal on any exited wallet, even if the chain propagation period has not expired. In normal operation, off-chain system proactively withdraw exited wallets. If off-chain systems are offline, `withdrawExitAdmin` allows the admin or dispatcher wallet to similarly proactively withdraw exited wallets. Withdrawing all exited wallets provides a stable chain propagation period to resynchronize off-chain systems with on-chain state during system recovery.